### PR TITLE
Tomcat sudo administration

### DIFF
--- a/manifests/classes/tomcat-administration.pp
+++ b/manifests/classes/tomcat-administration.pp
@@ -8,7 +8,7 @@ to:
 - restart tomcat instances.
 
 Requires:
-- management of /etc/sudoers with common::concatfilepart
+- definition sudo::directive from module camptocamp/puppet-sudo
 
 Warning: will overwrite /etc/sudoers !
 
@@ -19,9 +19,8 @@ class tomcat::administration {
     ensure => present,
   }
 
-  common::concatfilepart { "sudoers.tomcat":
+  sudo::directive { "tomcat-administration":
     ensure => present,
-    file => "/etc/sudoers",
     content => template("tomcat/sudoers.tomcat.erb"),
     require => Group["tomcat-admin"],
   }


### PR DESCRIPTION
Take advantage of the new definition **sudo:: directive** that was added in the puppet-module sudo and that uses directive #includedir in **versions >= 1.7.2**

Feed-back welcome
