### PR TITLE
tomcat init script - change directory to tomcat base dir to prevent relat

### DIFF
--- a/templates/tomcat.init.erb
+++ b/templates/tomcat.init.erb
@@ -28,6 +28,8 @@ start() {
     return 0
   fi
 
+  # Change directory to prevent path problems
+  cd <%= basedir %>
   # Source JVM parameters
   test -r <%= basedir %>/bin/setenv.sh && . <%= basedir %>/bin/setenv.sh
 


### PR DESCRIPTION
tomcat init script - change directory to tomcat base dir to prevent relative path problems
