### PR TITLE
tomcat::connector - added "generic" option argument - as connectors may h

### DIFF
--- a/manifests/definitions/tomcat-connector.pp
+++ b/manifests/definitions/tomcat-connector.pp
@@ -61,6 +61,7 @@ define tomcat::connector($ensure="present",
                          $redirect_port=8443,
                          $scheme=false,
                          $executor=false,
+                         $options=[],
                          $manage=false) {
 
   include tomcat::params

--- a/templates/connector.xml.erb
+++ b/templates/connector.xml.erb
@@ -14,6 +14,7 @@
 <% if executor -%>
            executor="<%= executor %>"
 <% end -%>
+           <%= options.collect! {|i| "#{i}" }.join("\n") %>
            protocol="<%= protocol %>" 
            connectionTimeout="<%= connection_timeout %>" 
            redirectPort="<%= redirect_port %>" />


### PR DESCRIPTION
tomcat::connector - added "generic" option argument - as connectors may have many options, we will not list them all
