### PR TITLE
tomcat::instance - absent could not work properly, as tomcat::connector ...

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -366,7 +366,12 @@ define tomcat::instance($ensure="present",
       file {$basedir:
         ensure  => absent,
         recurse => true,
-        force   => true,
+        force   => true;
+
+        "${basedir}/conf":
+        ensure  => absent,
+        recurse => true,
+        force   => true;
       }
     }
   }


### PR DESCRIPTION
...requires ${basedir}/conf directory.
