### PR TITLE
tomcat::connector: remove unnecessary file require

### DIFF
--- a/manifests/connector.pp
+++ b/manifests/connector.pp
@@ -80,11 +80,8 @@ define tomcat::connector($ensure="present",
     content => template("tomcat/connector.xml.erb"),
     replace => $manage,
     require => $executor ? {
-      false   => File["${tomcat::params::instance_basedir}/${instance}/conf"],
-      default => [
-        Tomcat::Executor[$executor],
-        File["${tomcat::params::instance_basedir}/${instance}/conf"],
-      ],
+      false   => undef,
+      default => Tomcat::Executor[$executor],
     },
   }
 


### PR DESCRIPTION
Immediate parent file resources are auto-required so it was superfluous. Plus
this require caused an error when the related tomcat::instance was set to
ensure => absent.

Is is meant to replace a pull-request from cjeanneret (https://github.com/camptocamp/puppet-tomcat/pull/10)
