### PR TITLE
tomcat: tomcat.init.erb - remove sourcing of setenv.sh

### DIFF
--- a/templates/tomcat.init.erb
+++ b/templates/tomcat.init.erb
@@ -30,8 +30,6 @@ start() {
 
   # Change directory to prevent path problems
   cd <%= basedir %>
-  # Source JVM parameters
-  test -r <%= basedir %>/bin/setenv.sh && . <%= basedir %>/bin/setenv.sh
 
   # Remove pidfile if still around
   test -f $CATALINA_PID && rm -f $CATALINA_PID


### PR DESCRIPTION
setenv.sh is already sourced by catalina.sh which is used by the init script,
which caused it to be sourced twice. This is a problem when variables are only
appended to.

I tested it on a Debian server were tomcat is installed by packages and a RedHat server where it's installed from source. I hope there's no corner cases which would break with this.
