### PR TITLE
Missing uppercase in RedHat name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,7 +38,7 @@ class tomcat::params {
       "Debian" => $lsbdistcodename ? {
         /lenny|squeeze/ => "6",
       },
-      "Redhat" => $lsbdistcodename ? {
+      "RedHat" => $lsbdistcodename ? {
         "Tikanga"  => "5.5",
         "Santiago" => "6",
       }


### PR DESCRIPTION
Just a typo:
facter|grep operatingsystem
operatingsystem => RedHat
