### PR TITLE
tomcat::redhat: Allow to change tomcat user shell on rhel6

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -74,7 +74,15 @@ class tomcat::redhat inherits tomcat::package {
       
       Package["tomcat"] { name => $tomcat }
 
+      User[ 'tomcat' ] {
+        shell => $tomcat_shell? {
+          ''      => '/sbin/nologin',
+          default => $tomcat_shell,
+        }
+      }
+
     }
+
   }
 
   User["tomcat"] { 


### PR DESCRIPTION
By setting $tomcat_shell variable
The default shell for tomcat on rhel6 is /sbin/nologin.
