### PR TITLE
Update custom init script.

### DIFF
--- a/templates/tomcat.init.erb
+++ b/templates/tomcat.init.erb
@@ -15,9 +15,9 @@ export CATALINA_PID=<%= basedir %>/temp/tomcat.pid
 
 # For SELinux we need to use 'runuser' not 'su'
 if [ -x "/sbin/runuser" ]; then
-    SU="/sbin/runuser"
+    SU="/sbin/runuser -s /bin/sh"
 else
-    SU="su"
+    SU="su -s /bin/sh"
 fi
 
 start() {


### PR DESCRIPTION
To allow instance to start with the default login shell of user tomcat on RHEL6.
https://bugzilla.redhat.com/show_bug.cgi?id=678671

Default login shell is /sbin/nologin.
