### PR TITLE
Ubuntu precise support added in tomcat module (debian.pp and params.pp)

### DIFF
--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -17,7 +17,7 @@ Usage:
 class tomcat::debian inherits tomcat::package {
 
   # avoid partial configuration on untested-debian-releases
-  if $lsbdistcodename !~ /^(lenny|squeeze)$/ {
+  if $lsbdistcodename !~ /^(lenny|squeeze|precise)$/ {
     fail "class ${name} not tested on ${operatingsystem}/${lsbdistcodename}"
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,6 +41,9 @@ class tomcat::params {
       "RedHat" => $lsbdistcodename ? {
         "Tikanga"  => "5.5",
         "Santiago" => "6",
+      },
+      "Ubuntu" => $lsbdistcodename ? {
+        "precise" => "6",
       }
     }
 


### PR DESCRIPTION
Same as before, support for Ubuntu Precise in the puppet-tomcat module.
