### PR TITLE
SLC Carbon support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@ Example usage:
 */
 class tomcat {
   case $::osfamily {
-    RedHat,SLC: { include tomcat::redhat }
+    RedHat: { include tomcat::redhat }
     Debian: { include tomcat::debian }
     default: { fail "Unsupported OS family ${::osfamily}" }
   }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -240,7 +240,7 @@ define tomcat::instance($ensure="present",
         $javahome = '/etc/alternatives/jre'
       }
       SLC: {
-	$javahome = "/usr/lib/jvm/jre"
+        $javahome = "/usr/lib/jvm/jre"
       }
       Debian,Ubuntu: {
         $javahome = '/usr'

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -75,7 +75,7 @@ class tomcat::redhat inherits tomcat::package {
       Package["tomcat"] { name => $tomcat }
 
     }
-    default: { fail "$lsbdistcodename not defined." }
+    default: { fail "${::lsbdistcodename} not defined." }
   }
 
   User["tomcat"] { 


### PR DESCRIPTION
Hello, (first time I do a pull request, sorry if I made any mistake

I have made minimal changes to the module so it works with: Scientific Linux CERN SLC release 6.3 (Carbon). Which is basically a clone of redhat6.

I also added a default statement in manifests/redhat.pp so if $lsbdistcodename is not defined, it fails. I forgot to define it, and the error puppet gave me was far from useful (an error in the user creation). 
