### PR TITLE
set system=>true on non human user accounts

### DIFF
--- a/manifests/administration.pp
+++ b/manifests/administration.pp
@@ -17,6 +17,7 @@ class tomcat::administration {
 
   group { "tomcat-admin":
     ensure => present,
+    system => true,
   }
 
   sudo::directive { "tomcat-administration":

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -21,7 +21,8 @@ class tomcat::base {
     groups => $tomcat_groups? {
       ''      => undef,
       default => $tomcat_groups,
-    }
+    },
+    system => true,
   }
 
   file { "/var/log/tomcat":


### PR DESCRIPTION
This is important to avoid uid/gid conflicts with accounts created
with fixed uids in normal user range.

This patch won't break existing configs because it only influences the
uid generation on new user / group creation and has no impact on existing
resources.
