### PR TITLE
Added JPDA (remote debugging) options to instance

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -40,6 +40,9 @@ Parameters:
 - *ajp_port*: tomcat's AJP port, defaults to 8009.
 - *ajp_address*: define the IP address tomcat's AJP server must listen on.
   Defaults to all addresses.
+- *jpda*: Boolean, whether or not to enable JPDA (remote debugging)
+- *jpda_port*: tomcat's JPDA port, defaults to 8000.
+- *jpda_transport*: Transport method for JPDA, defaults to dt_socket.
 - *conf_mode*: can be used to change the permissions on
   /srv/tomcat/$name/conf/, because some webapps require the ability to write
   their own config files. Defaults to 2570 (writeable only by $group members).
@@ -100,6 +103,9 @@ define tomcat::instance(
   $http_address    = false,
   $ajp_port        = '8009',
   $ajp_address     = false,
+  $jpda_transport  = "dt_socket",
+  $jpda_port       = "8000",
+  $jpda            = false,  
   $conf_mode       = '',
   $logs_mode       = '',
   $server_xml_file = '',

--- a/templates/tomcat.init.erb
+++ b/templates/tomcat.init.erb
@@ -12,6 +12,8 @@ export JAVA_HOME=<%= @javahome %>
 export CATALINA_HOME=<%= @catalinahome %>
 export CATALINA_BASE=<%= @basedir %>
 export CATALINA_PID=<%= @basedir %>/temp/tomcat.pid
+export JPDA_ADDRESS=<%= jpda_port %>
+export JPDA_TRANSPORT=<%= jpda_transport %>
 
 # For SELinux we need to use 'runuser' not 'su'
 if [ -x "/sbin/runuser" ]; then
@@ -38,7 +40,12 @@ start() {
   # Remove pidfile if still around
   test -f $CATALINA_PID && rm -f $CATALINA_PID
 
-  $SU tomcat -c "umask 0002; $CATALINA_HOME/bin/catalina.sh start" > /dev/null
+  CATALINA_START_PARAMS="start"
+<% if jpda -%>
+  CATALINA_START_PARAMS="jpda $CATALINA_START_PARAMS"
+<% end -%>
+
+  $SU tomcat -c "umask 0002; $CATALINA_HOME/bin/catalina.sh $CATALINA_START_PARAMS" > /dev/null
 }
 
 stop() {


### PR DESCRIPTION
Maybe this is already in here and I just don't know where...but this adds the ability to enable remote debugging. With this enabled, you will be able to attach a debugger process from within your IDE (Eclipse, NetBeans, IntelliJ, etc)

**Example Usage:**

``` puppet
tomcat::instance {"my-instance":
  ensure         => present,
  jpda           => true,
  jpda_port      => "8000",
  jpda_transport => "dt_socket",
}
```
