### PR TITLE
Bad base directory for logginf library in source case

### DIFF
--- a/manifests/logging.pp
+++ b/manifests/logging.pp
@@ -10,6 +10,10 @@
 #
 class tomcat::logging (
   $conffile    = "puppet:///modules/${module_name}/conf/log4j.rolling.properties",
+  $base_path   = $tomcat::version ? {
+    '5'     => "${tomcat::home}/common/lib",
+    default => "${tomcat::home}/lib",
+  },
 ) {
 
   $package = $::osfamily? {
@@ -21,18 +25,16 @@ class tomcat::logging (
     ensure => present,
   }
 
-  $base_path = $tomcat::version ? {
-    '5'     => "${tomcat::home}/common/lib",
-    default => "${tomcat::home}/lib",
-  }
-
   $log4j = $::osfamily? {
     Debian => '/usr/share/java/log4j-1.2.jar',
     RedHat => '/usr/share/java/log4j.jar',
   }
 
-  file {$base_path:
-    ensure => directory,
+  # The source class need (and define) this directory before logging
+  if $::tomcat::sources == false {
+    file {$base_path:
+      ensure => directory,
+    }
   }
 
   file {'/var/log/tomcat':

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -33,7 +33,8 @@ class tomcat::source (
   }
 
   # link logging libraries from java
-  class { '::tomcat::logging': }
+  class { '::tomcat::logging':
+    base_path => $tomcat_home, }
 
   $a_version = split($version, '[.]')
   $maj_version = $a_version[0]


### PR DESCRIPTION
The other solution was to define tomcat::home in the source class, but I'm not sure that's a good thing to have tomcat in /opt/apache-tomcat-NNN and the logging library in /var/lib/tomcatN/. And it may not work (case not tested).
This solution isn't that pretty, so 3rd solution welcome. Comment&idea too!
