### PR TITLE
lsbmajdistrelease and operatingsystemmajrelease facts are not set in CentOS, use operatingsystemrelease

### DIFF
--- a/manifests/install/redhat.pp
+++ b/manifests/install/redhat.pp
@@ -4,8 +4,8 @@
 #
 class tomcat::install::redhat {
 
-  case $::operatingsystemmajrelease {
-    5: {
+  case $::operatingsystemrelease {
+    /^5.*/: {
       file {'/usr/share/tomcat5/bin/catalina.sh':
         ensure  => link,
         target  => "/usr/bin/dtomcat${tomcat::version}",
@@ -13,7 +13,7 @@ class tomcat::install::redhat {
       }
     }
 
-    6: {
+    /^6.*/: {
       file {"/usr/share/tomcat${tomcat::version}/bin/setclasspath.sh":
         ensure  => file,
         owner   => root,
@@ -32,7 +32,7 @@ class tomcat::install::redhat {
       }
     }
     default: {
-      fail "Don't know what to do for ${::operatingsystem}/${::operatingsystemmajrelease}"
+      fail "Don't know what to do for ${::operatingsystem}/${::operatingsystemrelease}"
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,9 +2,9 @@ class tomcat::params {
 
   $version = $::osfamily? {
     Debian => '6',
-    RedHat => $::lsbmajdistrelease ? {
-      '5' => '5',
-      '6' => '6',
+    RedHat => $::operatingsystemrelease ? {
+      /^5.*/ => '5',
+      /^6.*/ => '6',
     }
   }
 


### PR DESCRIPTION
Broken in CentOS again. Same problem as in Issue #33
