### PR TITLE
setclasspath needs a requirement to be created after package installation

### DIFF
--- a/manifests/install/redhat.pp
+++ b/manifests/install/redhat.pp
@@ -21,15 +21,13 @@ class tomcat::install::redhat {
         mode    => '0755',
         source  => "puppet:///modules/${module_name}/setclasspath.sh-6.0.24",
         require => Package["tomcat${tomcat::version}"],
-      }
-
+      } ->
       file {"/usr/share/tomcat${tomcat::version}/bin/catalina.sh":
         ensure  => file,
         owner   => root,
         group   => root,
         mode    => '0755',
         source  => "puppet:///modules/${module_name}/catalina.sh-6.0.24",
-        require => File["/usr/share/tomcat${tomcat::version}/bin/setclasspath.sh"],
       }
     }
     default: {


### PR DESCRIPTION
Otherwise it tries to create setclasspath.sh when the dir doesn't yet exist, under RedHat 6
