### PR TITLE
Remove dependency on LSB facts

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,7 @@ class tomcat::params {
 
   $version = $::osfamily? {
     Debian => '6',
-    RedHat => $::lsbmajdistrelease ? {
+    RedHat => $::operatingsystemmajrelease ? {
       '5' => '5',
       '6' => '6',
     }


### PR DESCRIPTION
LSB facts require redhat-lsb installed, which may not be the case on a minimal
installation. It also pulls in many dependencies.

This also fixes https://github.com/camptocamp/puppet-tomcat/pull/60.
