### PR TITLE
Tomcat dir owner bug fix

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -418,19 +418,19 @@ define tomcat::instance(
         # Tomcat usually write there
         "${basedir}/logs":
           ensure => directory,
-          owner  => 'tomcat',
+          owner  => $owner,
           group  => $group,
           mode   => $logsmode,
           before => Service["tomcat-${name}"];
         "${basedir}/work":
           ensure => directory,
-          owner  => 'tomcat',
+          owner  => $owner,
           group  => $group,
           mode   => '2770',
           before => Service["tomcat-${name}"];
         "${basedir}/temp":
           ensure => directory,
-          owner  => 'tomcat',
+          owner  => $owner,
           group  => $group,
           mode   => '2770',
           before => Service["tomcat-${name}"];
@@ -443,7 +443,7 @@ define tomcat::instance(
         #
         file { "${basedir}/webapps/sample.war":
           ensure  => present,
-          owner   => 'tomcat',
+          owner   => $owner,
           group   => $group,
           mode    => '0460',
           source  => "puppet:///modules/${module_name}/sample.war",


### PR DESCRIPTION
When creating an instance with the owner parameter set, the directories work, logs and temp are set to be owned by user 'tomcat' instead of the specified user. Thus a source install will always require a user named 'tomcat', even if a different user is specified.

This PR correctly sets the owner.

All unit tests pass.
