### PR TITLE
Ensure $tomcat::home exists before creating a directory below it.

### DIFF
--- a/manifests/juli/debian.pp
+++ b/manifests/juli/debian.pp
@@ -11,6 +11,7 @@ class tomcat::juli::debian {
 
   file { "${tomcat::home}/extras/":
     ensure  => directory,
+    require => Package["tomcat${tomcat::version}"],
   }
 
   archive::download { 'tomcat-juli.jar':


### PR DESCRIPTION
During runs on a Debian machine I consistently run into:

```
Error: Cannot create /usr/share/tomcat6/extras; parent directory /usr/share/tomcat6 does not exist
Error: /Stage[main]/Tomcat::Juli::Debian/File[/usr/share/tomcat6/extras/]/ensure: change from absent to directory failed: Cannot create /usr/share/tomcat6/extras; parent directory /usr/share/tomcat6 does not exist
```

Which seems odd given this code in `install.pp`:

```
    package {"tomcat${tomcat::version}":
      ensure => present,
    } ->
    class {'::tomcat::juli': } 
```

I'd assume that installing the package creates `tomcat::home`; and re-running the agent after it has failed results in a successful run. Since none of the files in `debian.pp` really need to tomcat package to be installed, perhaps we can just create the directory here and prevent a consistent failure on Debian.
