### PR TITLE
refresh the service when the instance configuration changes.

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -206,7 +206,11 @@ define tomcat::instance(
       manage   => $manage,
       address  => $http_address,
       group    => $group,
-      owner    => $owner
+      owner    => $owner,
+      notify   => $manage ? {
+        true    => Service["tomcat-${name}"],
+        default => undef,
+      },
     }
 
     tomcat::connector{"ajp-${ajp_port}-${name}":
@@ -217,7 +221,11 @@ define tomcat::instance(
       manage   => $manage,
       address  => $ajp_address,
       group    => $group,
-      owner    => $owner
+      owner    => $owner,
+      notify   => $manage ? {
+        true    => Service["tomcat-${name}"],
+        default => undef,
+      },
     }
 
   } else {


### PR DESCRIPTION
For example when changing `http_port` it would be helpful if the service becomes available on the new port, instead of it having it to manually restart.
