### PR TITLE
Allow to completely manage the logrotate file

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -62,6 +62,8 @@
 #   server.xml
 # - *executor*: an array of tomcat::executor name (string) to include in
 #   server.xml
+# - *catalina_logrotate*: install an UNMANAGED logrotate configuration file,
+#   to handle the catalina.out file of the instance. Default to true.
 #
 # Requires:
 # - one of the tomcat classes which installs tomcat binaries.
@@ -116,6 +118,7 @@ define tomcat::instance(
   $seltype            = 'initrc_exec_t',
   $instance_basedir   = false,
   $tomcat_version     = false,
+  $catalina_logrotate = true,
 ) {
 
   Class['tomcat::install'] -> Tomcat::Instance[$title]
@@ -494,10 +497,12 @@ define tomcat::instance(
   # Default rotation of catalina.out
   # Not managed by default
   # TODO: managed mode with more options ?
-  file{ "/etc/logrotate.d/catalina-${name}":
-    ensure  => $present,
-    replace => false,
-    content => template( 'tomcat/logrotate.catalina.erb' ),
+  if $catalina_logrotate {
+    file{ "/etc/logrotate.d/catalina-${name}":
+      ensure  => $present,
+      replace => false,
+      content => template( 'tomcat/logrotate.catalina.erb' ),
+    }
   }
 
   # Init and env scripts


### PR DESCRIPTION
The "replace => false" option for the file type still manage the user, group and mode of the file.
If you have global option in a File, it will be used, even if you don't want.

Using inheritance to manage the owner/group/mod of the logrotate file, itsn't a nice solution.
It's easier not to install the file, if you really have specific needs.
