### PR TITLE
Support Scientific Linux

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -282,6 +282,9 @@ define tomcat::instance(
       RedHat: {
         $javahome = '/usr/lib/jvm/java'
       }
+      Scientific: {
+        $javahome = '/usr/lib/jvm/java'
+      }
       CentOS: {
         $javahome = '/etc/alternatives/jre'
       }


### PR DESCRIPTION
Scientific Linux is in the RedHat Family. Maybe consider using `$::operatingsystemfamily` instead.
