### PR TITLE
Remove unused parameter in logrotate configuration

### DIFF
--- a/templates/logrotate.catalina.erb
+++ b/templates/logrotate.catalina.erb
@@ -1,7 +1,6 @@
 # file installed but NOT managed by Puppet
 <%= @basedir %>/logs/catalina.out {
       copytruncate
-      weekly
       size 500M
       dateext
       rotate 53


### PR DESCRIPTION
As weekly and size are mutually exclusive, the last read is used.
Don't let module user believe that logrotate uses this two options at the same time.
