### PR TITLE
Adds a parameter extra_jars to tomcat instances

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -119,6 +119,7 @@ define tomcat::instance(
   $instance_basedir   = false,
   $tomcat_version     = false,
   $catalina_logrotate = true,
+  $extra_jars         = [],
 ) {
 
   Class['tomcat::install'] -> Tomcat::Instance[$title]
@@ -139,6 +140,7 @@ define tomcat::instance(
   validate_array($connector)
   validate_array($executor)
   validate_bool($manage)
+  validate_array($extra_jars)
 
   $_basedir = $instance_basedir? {
     false   => $tomcat::instance_basedir,
@@ -322,6 +324,13 @@ define tomcat::instance(
           content => template("${module_name}/body2_${serverdotxml}"),
         }
       }
+      # extra jars
+      #tomcat::instance::extra_jar { $extra_jars: }
+      tomcat::instance::link { $extra_jars:
+        fromdir => "${basedir}/lib",
+                todir     => '/usr/share/java',
+      }
+
       file {
         # Nobody usually write there
         $basedir:
@@ -565,5 +574,15 @@ define tomcat::instance(
   # Logrotate
   file {"/etc/logrotate.d/tomcat-${name}.conf":
     ensure => absent,
+  }
+}
+
+define tomcat::instance::link (
+    $fromdir,
+    $todir,
+    ) {
+  file { "${fromdir}/${name}":
+    ensure => link,
+    target   => "${todir}/${name}",
   }
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -325,10 +325,8 @@ define tomcat::instance(
         }
       }
       # extra jars
-      #tomcat::instance::extra_jar { $extra_jars: }
-      tomcat::instance::link { $extra_jars:
-        fromdir => "${basedir}/lib",
-                todir     => '/usr/share/java',
+      tomcat::instance::link_extra_jar { $extra_jars:
+        instance_libdir => "${basedir}/lib",
       }
 
       file {
@@ -577,12 +575,18 @@ define tomcat::instance(
   }
 }
 
-define tomcat::instance::link (
-    $fromdir,
-    $todir,
+# TODO after discussing with Mickael he seems to think that this
+# should be nested in its own .pp file. Not sure though, because it 
+# is related only to tomcat instances.
+define tomcat::instance::link_extra_jar (
+      $instance_libdir,
     ) {
-  file { "${fromdir}/${name}":
+  # TODO Should'nt this be a function in puppet-stdlib ?
+  $bname = inline_template('<%= File.basename(@name) %>')
+  $from = "${instance_libdir}/${bname}"
+  $to = $name
+  file { "${from}":
     ensure => link,
-    target   => "${todir}/${name}",
+    target   => "${to}",
   }
 }


### PR DESCRIPTION
This PR is meant to provide the way to easily add some extra dependencies that have to be shared across the different webapps that would be deployed into the tomcat instance.

Here is an example of manifest I used to test it:

```puppet
Exec {
  path => '/usr/bin:/usr/local/bin:/usr/sbin:/bin:/sbin:/usr/local/sbin'
}
include tomcat
package {'libjai-imageio-core-java': ensure => 'installed' }
tomcat::instance {'tc-lib-extra-jars':
  ensure    => present,
  http_port => '8080',
  extra_jars => [ '/usr/share/java/jai_imageio.jar',
                  '/usr/share/java/jai_core.jar',
                  '/usr/share/java/jai_codec.jar' ]
}
```

This would create symlinks as follows:

```
admin@debian-7-amd64:/srv/tomcat/tc-lib-extra-jars/lib$ ls -lh
total 0
lrwxrwxrwx 1 root adm 29 May  3 13:36 jai_codec.jar -> /usr/share/java/jai_codec.jar
lrwxrwxrwx 1 root adm 28 May  3 13:36 jai_core.jar -> /usr/share/java/jai_core.jar
lrwxrwxrwx 1 root adm 31 May  3 13:36 jai_imageio.jar -> /usr/share/java/jai_imageio.jar
```

Since I'm pretty new to puppet, I don't know if this is the perfect way to do so, but if you've any feedback, do not hesitate to comment ; i deliberately left some TODOs in the code on some unsure statements.

Hth,