### PR TITLE
OSFamily + tests

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -280,7 +280,7 @@ define tomcat::instance(
 
   # Define default JAVA_HOME used in tomcat.init.erb
   if $java_home == '' {
-    case $::operatingsystem {
+    case $::osfamily {
       RedHat: {
         $javahome = '/usr/lib/jvm/java'
       }

--- a/spec/defines/parameters.rb
+++ b/spec/defines/parameters.rb
@@ -51,4 +51,17 @@
     'tomcat_version'            => '6',
     'sudo_version'              => '1.7.3',
   },
+  'ORACLELINUX6' => {
+    'java_home'                 => '/usr/lib/jvm/java',
+    'log4j'                     => 'log4j',
+    'logging'                   => 'jakarta-commons-logging',
+    'lsbmajdistrelease'         => '6',
+    'operatingsystem'           => 'OracleLinux',
+    'operatingsystemmajrelease' => '6',
+    'osfamily'                  => 'RedHat',
+    'tomcat_home'               => '/var/lib/tomcat',
+    'tomcat_package'            => 'tomcat6',
+    'tomcat_version'            => '6',
+    'sudo_version'              => '1.7.3',
+  },
 }


### PR DESCRIPTION
We’re using OracleLinux (RedHat variant) and using ::operatingsystem
causes failures; Rather than adding every possible OS to the list, I
believe it is better to instead use ::osfamily.  I also added a test-case.
