### PR TITLE
Added dependency puppetlabs/stdlib to modulefile

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,3 +8,4 @@ description  'Tomcat Module for Puppet'
 project_page 'https://github.com/camptocamp/puppet-tomcat'
 dependency   'camptocamp/archive'
 dependency   'theforeman/concat_native'
+dependency   'puppetlabs/stdlib


### PR DESCRIPTION
Was testing this module standalone and it was bugging me with "Error: Unknown function validate_re at /root/puppet/tomcat/manifests/init.pp:11 on node .localdomain". Might as well add it.
