### PR TITLE
init tomcat7 service start-up fix

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,14 +20,12 @@ class tomcat::install {
     file {"/etc/init.d/tomcat${tomcat::version}":
       ensure  => file,
       mode    => '0644',
-      require => Package["tomcat${tomcat::version}"],
     }
     service {"tomcat${tomcat::version}":
       ensure => stopped,
       enable => false,
-      require => File["/etc/init.d/tomcat${tomcat::version}"],
+      before => File["/etc/init.d/tomcat${tomcat::version}"],
     }
-    
   } else {
     class {'tomcat::source': }
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,14 +18,16 @@ class tomcat::install {
     # Moved from Class[tomcat::service] to here so that we can create a
     # tomcat::service definition.
     file {"/etc/init.d/tomcat${tomcat::version}":
-      ensure => file,
-      mode   => '0644',
-    } ->
+      ensure  => file,
+      mode    => '0644',
+      require => Package["tomcat${tomcat::version}"],
+    }
     service {"tomcat${tomcat::version}":
       ensure => stopped,
       enable => false,
+      require => File["/etc/init.d/tomcat${tomcat::version}"],
     }
-
+    
   } else {
     class {'tomcat::source': }
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,6 +25,7 @@ class tomcat::install {
       ensure => stopped,
       enable => false,
       before => File["/etc/init.d/tomcat${tomcat::version}"],
+      require => Package["tomcat${tomcat::version}"],
     }
   } else {
     class {'tomcat::source': }

--- a/templates/body2_server.xml.tomcat7.erb
+++ b/templates/body2_server.xml.tomcat7.erb
@@ -41,10 +41,9 @@
              Note: The pattern used is equivalent to using pattern="common" -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log." suffix=".txt"
-               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+               pattern="%h %l %u %t &quot;%r&quot; %s %b %D" />
 
       </Host>
     </Engine>
   </Service>
 </Server>
-


### PR DESCRIPTION
When the tomcat7 gets installed on the ubuntu under PE 3.2.3, the default service of tomcat7 starts and continues to run which prevents a single instance from running.  

The fix seems to be moving from arrows (->) dependency to using explicit requires.