### PR TITLE
The init script does not propagate JAVA_HOME to the tomcat user env

### DIFF
--- a/templates/tomcat.init.erb
+++ b/templates/tomcat.init.erb
@@ -38,7 +38,7 @@ start() {
   # Remove pidfile if still around
   test -f $CATALINA_PID && rm -f $CATALINA_PID
 
-  $SU <%= @owner %> -c "umask 0002; $CATALINA_HOME/bin/catalina.sh start" > /dev/null
+  $SU <%= @owner %> -c "umask 0002; export JAVA_HOME=$JAVA_HOME; $CATALINA_HOME/bin/catalina.sh start" > /dev/null
 }
 
 stop() {


### PR DESCRIPTION
therefor, the stop do not work anymore and you can run tomcat with an unwanted JRE/JDK

Best,
Jerome