### PR TITLE
init - fuzzy jvm detection

### DIFF
--- a/templates/tomcat.init.erb
+++ b/templates/tomcat.init.erb
@@ -86,7 +86,7 @@ stop() {
 
 findpid() {
   pid=""
-  pid=$(pgrep -U <%= @owner %> -f "^$JAVA_HOME/bin/java.*catalina.base=<%= @basedir %>")
+  pid=$(pgrep -U <%= @owner %> -f "^.*/bin/java.*catalina.base=<%= @basedir %>")
 
   # validate output of pgrep
   if ! [ "$pid" = "" ] && ! [ "$pid" -gt 0 ]; then


### PR DESCRIPTION
In case of customized java_home environment variable in `${CATALINA_BASE}/setenv-local.sh`, the superseded value is not taken into account in the initscript (because the `setenv*` files are not sourced until `catalina.sh` is called).

This PR aims to be a bit more "fuzzy" in the process id detection.

Tests: unit tests OK.