### PR TITLE
Use puppetlabs-concat instead of theforeman-concat_native

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,7 @@ fixtures:
     augeasproviders_core: 'herculesteam-augeasproviders_core'
     augeasproviders_shellvar: 'herculesteam-augeasproviders_shellvar'
     archive: 'camptocamp-archive'
-    concat_native: 'theforeman-concat_native'
+    concat: 'puppetlabs-concat'
     inifile: 'puppetlabs-inifile'
     stdlib: 'puppetlabs-stdlib'
     systemd: 'camptocamp-systemd'

--- a/manifests/connector.pp
+++ b/manifests/connector.pp
@@ -89,31 +89,37 @@ define tomcat::connector(
     default => Tomcat::Executor[$executor],
   }
 
-  concat_build { "connector_${name}": } ->
-  file {"${instance_basedir}/${instance}/conf/connector-${name}.xml":
+  concat { "${instance_basedir}/${instance}/conf/connector-${name}.xml":
     ensure  => $ensure,
     owner   => $owner,
     group   => $group,
     mode    => $filemode,
-    source  => concat_output("connector_${name}"),
     replace => $manage,
     require => $require,
   }
-  concat_fragment { "connector_${name}+01":
+  concat::fragment { "connector_${name}+01":
+    target  => "${instance_basedir}/${instance}/conf/connector-${name}.xml",
     content => template('tomcat/connector_header.xml.erb'),
+    order   => '01',
   }
-  concat_fragment { "connector_${name}+99":
+  concat::fragment { "connector_${name}+99":
+    target  => "${instance_basedir}/${instance}/conf/connector-${name}.xml",
     content => template('tomcat/connector_footer.xml.erb'),
+    order   => '99',
   }
 
   if versioncmp($::tomcat::version, '5') != 0 {
-    concat_fragment { "server.xml_${instance}+03_connector_${name}":
+    concat::fragment { "server.xml_${instance}+03_connector_${name}":
+      target  => "${instance_basedir}/${instance}/conf/server.xml",
       content => "  <!ENTITY connector-${name} SYSTEM \"connector-${name}.xml\">\n",
+      order   => '03',
     }
 
-    concat_fragment { "server.xml_${instance}+06_connector_${name}":
+    concat::fragment { "server.xml_${instance}+06_connector_${name}":
+      target  => "${instance_basedir}/${instance}/conf/server.xml",
       content => "    <!-- See conf/connector-${name}.xml for this connector's config. -->
       &connector-${name};\n",
+      order   => '06',
     }
   }
 

--- a/manifests/executor.pp
+++ b/manifests/executor.pp
@@ -97,13 +97,17 @@ define tomcat::executor(
   }
 
   if versioncmp($::tomcat::version, '5') != 0 {
-    concat_fragment { "server.xml_${instance}+02_executor_${name}":
+    concat::fragment { "server.xml_${instance}+02_executor_${name}":
+      target  => "${instance_basedir}/${instance}/conf/server.xml",
       content => "  <!ENTITY executor-${name} SYSTEM \"executor-${name}.xml\">\n",
+      order   => '02',
     }
 
-    concat_fragment { "server.xml_${instance}+05_executor_${name}":
+    concat::fragment { "server.xml_${instance}+05_executor_${name}":
+      target  => "${instance_basedir}/${instance}/conf/server.xml",
       content => "    <!-- See conf/executor-${name}.xml for this executor's config. -->
       &executor-${name};\n",
+      order   => '05',
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -22,8 +22,8 @@
       "version_requirement": ">=0.3.0 <2.0.0"
     },
     {
-      "name": "theforeman/concat_native",
-      "version_requirement": ">=1.4.0 <2.0.0"
+      "name": "puppetlabs/concat",
+      "version_requirement": ">=1.0.0 <2.0.0"
     },
     {
       "name": "puppetlabs/inifile",

--- a/spec/defines/tomcat_connector_spec.rb
+++ b/spec/defines/tomcat_connector_spec.rb
@@ -166,10 +166,9 @@ describe 'tomcat::connector' do
 
         it { is_expected.to compile.with_all_deps }
         it {
-          is_expected.to contain_concat_build('connector_ConnectBar')
           is_expected.to contain_concat_fragment('connector_ConnectBar+01').with_content(/port="8442"/)
           is_expected.to contain_concat_fragment('connector_ConnectBar+99').with_content(/protocol="HTTP\/1.1"/)
-          is_expected.to contain_file('/srv/tomcat/instance1/conf/connector-ConnectBar.xml').with({
+          is_expected.to contain_concat('/srv/tomcat/instance1/conf/connector-ConnectBar.xml').with({
             'ensure'  => 'present',
             'owner'   => 'tomcat',
             'group'   => 'adm',

--- a/spec/defines/tomcat_instance_spec.rb
+++ b/spec/defines/tomcat_instance_spec.rb
@@ -249,12 +249,11 @@ describe 'tomcat::instance' do
           }
         else
           it {
-            should contain_file("/srv/tomcat/fooBar/conf/server.xml").with({
-              'ensure'  => 'file',
+            should contain_concat("/srv/tomcat/fooBar/conf/server.xml").with({
+              'ensure'  => 'present',
               'owner'   => 'tomcat',
               'group'   => 'adm',
               'mode'    => '0460',
-              'source'  => /server.xml_fooBar/,
             })
           }
 
@@ -263,8 +262,8 @@ describe 'tomcat::instance' do
 
       describe "should create bin/setenv.sh" do
         it {
-          should contain_file("/srv/tomcat/fooBar/bin/setenv.sh").with({
-            'ensure'  => 'file',
+          should contain_concat("/srv/tomcat/fooBar/bin/setenv.sh").with({
+            'ensure'  => 'present',
             'owner'   => 'root',
             'group'   => 'adm',
             'mode'    => '0754',
@@ -275,7 +274,7 @@ describe 'tomcat::instance' do
       describe "should create bin/setenv-local.sh" do
         it {
           should contain_file("/srv/tomcat/fooBar/bin/setenv-local.sh").with({
-            'ensure'  => 'file',
+            'ensure'  => 'present',
             'owner'   => 'root',
             'group'   => 'adm',
             'mode'    => '0574',
@@ -297,7 +296,7 @@ describe 'tomcat::instance' do
           case facts[:osfamily]
           when 'Debian'
             should contain_file('/etc/init.d/tomcat-fooBar').
-              with_ensure('file').
+              with_ensure('present').
               with_owner('root').
               with_mode('0755').
               with_content(/JAVA_HOME=\/usr/).
@@ -306,7 +305,7 @@ describe 'tomcat::instance' do
             if facts[:operatingsystemmajrelease].to_i < 7
               if facts[:operatingsystem] == 'CentOS'
                 should contain_file('/etc/init.d/tomcat-fooBar').
-                  with_ensure('file').
+                  with_ensure('present').
                   with_owner('root').
                   with_mode('0755').
                   with_content(%r{JAVA_HOME=/etc/alternatives/jre}).
@@ -314,7 +313,7 @@ describe 'tomcat::instance' do
                   with_content(/tomcat -c \"umask 0002;/)
               else
                 should contain_file('/etc/init.d/tomcat-fooBar').
-                  with_ensure('file').
+                  with_ensure('present').
                   with_owner('root').
                   with_mode('0755').
                   with_content(/JAVA_HOME=\/usr\/lib\/jvm\/java/).
@@ -338,16 +337,14 @@ describe 'tomcat::instance' do
           :setenv => ['JAVA_XMX="512m"', 'JAVA_XX_MAXPERMSIZE="512m"']
         }}
         it {
-          should contain_file('/srv/tomcat/fooBar/bin/setenv.sh').with({
-            'ensure'  => 'file',
+          should contain_concat('/srv/tomcat/fooBar/bin/setenv.sh').with({
+            'ensure'  => 'present',
             'owner'   => 'root',
             'group'   => 'adm',
             'mode'    => '0754',
           })
-          should contain_concat_build('setenv.sh_fooBar')
           should contain_concat_fragment('setenv.sh_fooBar+01_header').with_content(/JAVA_XMX=\"512m\"/)
           should contain_concat_fragment('setenv.sh_fooBar+01_header').with_content(/JAVA_XX_MAXPERMSIZE=\"512m\"/)
-          should contain_file('/srv/tomcat/fooBar/bin/setenv.sh')
         }
       end
 


### PR DESCRIPTION
thforeman-concat_native will be obsoleted soon in favor of puppetlabs-concat as it conflicts with puppetlabs-concat 2.0.0, so we have to migrate.