### PR TITLE
Prevent puppet restarting tomcat when it shouldn't

### DIFF
--- a/manifests/instance/service.pp
+++ b/manifests/instance/service.pp
@@ -18,9 +18,17 @@ define tomcat::instance::service(
     'absent'    => false,
   }
 
+  # Workaround to avoid puppet restarting tomcat
+  # when the service is notified
+  $_restart = $ensure ? {
+    'installed' => '/bin/true',
+    default     => undef,
+  }
+
   service {"tomcat-${name}":
     ensure  => $_ensure,
     enable  => $_enable,
+    restart => $_restart,
     # FIXME: is this still require ?
     pattern => "-Dcatalina.base=${tomcat::instance_basedir}/${name}",
   }


### PR DESCRIPTION
This is a bit hackish but the only way I found to prevent puppet from
managing the service at all.