### PR TITLE
Missing dep for Red Hat source installation. Hostmanager and manager support. Handling of tomcat-users.xml

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -65,6 +65,10 @@
 #   server.xml
 # - *catalina_logrotate*: install an UNMANAGED logrotate configuration file,
 #   to handle the catalina.out file of the instance. Default to true.
+# - *hostmanager*: if "true" it will enable deploy of hostmanager webapp.
+# - *manager*: if "true" it will enable deploy of manager webapp.
+# - *users*: Array of hashes containing structure like [ {username => "user", password => "secret", roles="manager-gui,admin"}  ], needed for hostmanager webapp.
+# - *roles*: Array of string containing roles to be placed in tomcat-users.xml, needed for hostmanager webapp.
 #
 # Requires:
 # - one of the tomcat classes which installs tomcat binaries.
@@ -91,6 +95,21 @@
 #       'JAVA_XMX="1200m"',
 #       'ADD_JAVA_OPTS="-Xms128m"'
 #     ],
+#   }
+#
+#   tomcat::instance { "bar":
+#     ensure      => present,
+#     server_port => 8006,
+#     http_port   => 8081,
+#     ajp_port    => 8010,
+#     users       => [ 
+#       { 
+#         username => "myuser"
+#         password => "mypassword"
+#         roles    => "manager-gui,admin"
+#       } 
+#     ]
+#     roles       => [ manager-gui, admin ]
 #   }
 #
 define tomcat::instance(
@@ -123,6 +142,10 @@ define tomcat::instance(
   $tomcat_version     = $tomcat::version,
   $catalina_logrotate = true,
   $java_opts          = undef,
+  $hostmanager        = false,
+  $manager            = false,
+  $users              = [],
+  $roles              = [],
 ) {
 
   Class['tomcat::install'] -> Tomcat::Instance[$title]
@@ -156,6 +179,8 @@ define tomcat::instance(
     owner              => $owner,
     sample             => $sample,
     webapp_mode        => $webapp_mode,
+    hostmanager        => $hostmanager,
+    manager            => $manager,
   }
 
   tomcat::instance::config { $title:
@@ -184,6 +209,10 @@ define tomcat::instance(
     version            => $version,
     web_xml_file       => $web_xml_file,
     java_opts          => $java_opts,
+    hostmanager        => $hostmanager,
+    manager            => $manager,
+    users              => $users,
+    roles              => $roles,
   }
 
   tomcat::instance::service { $title:

--- a/manifests/instance/config.pp
+++ b/manifests/instance/config.pp
@@ -25,6 +25,10 @@ define tomcat::instance::config(
   $server_xml_file = undef,
   $web_xml_file    = undef,
   $java_opts       = undef,
+  $hostmanager = false,
+  $manager = false,
+  $users = [],
+  $roles = [],
 ) {
   # lint:ignore:only_variable_string
   validate_re("${server_port}", '^[0-9]+$')
@@ -34,6 +38,9 @@ define tomcat::instance::config(
   validate_array($setenv)
   validate_array($connector)
   validate_array($executor)
+  validate_array($users)
+  validate_array($roles)
+
 
   ###
   # Configure connectors
@@ -205,6 +212,64 @@ define tomcat::instance::config(
     owner   => 'root',
     group   => $group,
     mode    => '0574',
+  }
+
+  ###
+  # Configure hostmanager & manager webapps 
+  #
+  
+  if !$tomcat::sources {
+    $webapps_base = $::osfamily ? {
+      'RedHat' => $::operatingsystemmajrelease ? {
+        '7'     => '/var/lib/tomcat/server/webapps',
+        default => "/var/lib/tomcat${tomcat::version}/server/webapps",
+      },
+      'Debian' => "/usr/share/tomcat${tomcat::version}-admin",
+    }
+  } else {
+     $webapps_base = "/opt/apache-tomcat/webapps"
+  }
+  
+      
+  if $manager {
+    file { "${catalina_base}/webapps/manager":
+      ensure => link,
+      target => "${webapps_base}/manager",
+    }
+  }elsif ($manage){
+    file { "${catalina_base}/webapps/manager":
+      ensure => absent,
+    }
+  }
+  
+  if $hostmanager {
+    file { "${catalina_base}/webapps/host-manager":
+      ensure => link,
+      target => "${webapps_base}/host-manager",
+    }
+  }elsif ($manage){
+    file { "${catalina_base}/webapps/host-manager":
+      ensure => absent,
+    }
+  }
+  
+  ###
+  # Configure users auth 
+  #
+  if ($users or $roles){
+    file { "${catalina_base}/conf/tomcat-users.xml":
+      ensure  => file,
+      owner   => $owner,
+      group   => $group,
+      mode    => $filemode,
+      source  => undef,
+      content => template("${module_name}/tomcat-users.xml.erb"),
+      replace => $manage,
+    }
+  }elsif (!$users and !$roles and $manage){
+    file { "${catalina_base}/conf/tomcat-users.xml":
+      ensure  => absent,
+    }
   }
 
   ###

--- a/manifests/instance/config.pp
+++ b/manifests/instance/config.pp
@@ -226,8 +226,8 @@ define tomcat::instance::config(
       },
       'Debian' => "/usr/share/tomcat${tomcat::version}-admin",
     }
-  } else {
-     $webapps_base = "/opt/apache-tomcat/webapps"
+  }else {
+    $webapps_base = '/opt/apache-tomcat/webapps'
   }
   
       
@@ -261,7 +261,7 @@ define tomcat::instance::config(
       ensure  => file,
       owner   => $owner,
       group   => $group,
-      mode    => $filemode,
+      mode    => '0664',
       source  => undef,
       content => template("${module_name}/tomcat-users.xml.erb"),
       replace => $manage,

--- a/manifests/instance/install.pp
+++ b/manifests/instance/install.pp
@@ -11,6 +11,8 @@ define tomcat::instance::install(
   $conf_mode   = undef,
   $sample      = undef,
   $webapp_mode = undef,
+  $hostmanager = undef,
+  $manager     = undef,
 ) {
 
   if defined(File[$tomcat::instance_basedir]) {
@@ -136,6 +138,17 @@ define tomcat::instance::install(
           group   => $group,
           mode    => '0460',
           content => file(sprintf('%s/files/sample.war', get_module_path($module_name))),
+        }
+      }
+      if ($manager or $hostmanager) {
+        if !$tomcat::sources {
+          $packageweb_name = $::osfamily ? {
+            'RedHat' => $::operatingsystemmajrelease ? {
+              '7'     => 'tomcat-admin-webapps',
+              default => "tomcat${tomcat::version}-admin-webapps",
+            },
+            'Debian' => "tomcat${tomcat::version}-admin",
+          }
         }
       }
     }

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -28,7 +28,7 @@ class tomcat::source {
     package {'redhat-lsb-core':
       ensure => installed,
       name   => 'redhat-lsb-core',
-    } 
+    }
   }
 
   $version     = $tomcat::src_version

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -24,6 +24,13 @@ class tomcat::source {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
+  if ( $::osfamily == 'RedHat' ){
+    package {'redhat-lsb-core':
+      ensure => installed,
+      name   => 'redhat-lsb-core',
+    } 
+  }
+
   $version     = $tomcat::src_version
   $sources_src = $tomcat::sources_src
 

--- a/templates/tomcat-users.xml.erb
+++ b/templates/tomcat-users.xml.erb
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- file created and managed by puppet -->
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tomcat-users>
+<!--
+  NOTE:  By default, no user is included in the "manager-gui" role required
+  to operate the "/manager/html" web application.  If you wish to use this app,
+  you must define such a user - the username and password are arbitrary.
+-->
+<!--
+  NOTE:  The sample user and role entries below are wrapped in a comment
+  and thus are ignored when reading this file. Do not forget to remove
+  <!.. ..> that surrounds them.
+-->
+
+<% @roles.each do |role| -%>
+  <role rolename="<%= role %>"/>
+<% end -%>
+
+<% @users.each do |userhash| -%>
+  <user username="<%= userhash['username'] %>" password="<%= userhash['password'] %>" roles="<%= userhash['roles'] %>"/>
+<% end -%>
+
+</tomcat-users>


### PR DESCRIPTION
Brand new pull request after correction of some LINT errors and one missing variable, thanks to @mcanevet:

*) Added missing dependency for source installation (redhat-lsb-core). 
*) Integrated support for handling auto-deploying of hostmanager and manager tomcat webapps.
*) Added support to tomcat-users.xml file for user authentication using hostmanager and manager webapps.

Usage example:
tomcat::instance { 
  "bar":
    ensure => present,
    server_port => 8006,
    http_port => 8081,
    ajp_port => 8010,
    manager => true,
    hostmanager => true,
    users => [ 
      { 
         username => "myuser"
         password => "mypassword"
         roles => "manager-gui,admin"
      } 
    ]
    roles => [ manager-gui, admin ]
}