### PR TITLE
tomcat::instance::install: manage logorate conf and use su for file rotation

### DIFF
--- a/manifests/instance/install.pp
+++ b/manifests/instance/install.pp
@@ -165,7 +165,6 @@ define tomcat::instance::install(
   if $catalina_logrotate {
     file{ "/etc/logrotate.d/catalina-${name}":
       ensure  => $present,
-      replace => false,
       content => template( 'tomcat/logrotate.catalina.erb' ),
     }
   }

--- a/manifests/instance/install.pp
+++ b/manifests/instance/install.pp
@@ -165,6 +165,9 @@ define tomcat::instance::install(
   if $catalina_logrotate {
     file{ "/etc/logrotate.d/catalina-${name}":
       ensure  => $present,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
       content => template( 'tomcat/logrotate.catalina.erb' ),
     }
   }

--- a/templates/logrotate.catalina.erb
+++ b/templates/logrotate.catalina.erb
@@ -1,4 +1,4 @@
-# file installed but NOT managed by Puppet
+# file managed by Puppet
 <%= @catalina_base %>/logs/catalina.out {
       copytruncate
       size 500M
@@ -7,5 +7,6 @@
       compress
       delaycompress
       missingok
-      create 644 tomcat tomcat-admin
+      create 644 <%= @owner %> <%= @group %>
+      su <%= @owner %> <%= @group %>
 }


### PR DESCRIPTION
Enable full management of logroate configuration using puppet and use appropriate owner and group.
