### PR TITLE
Fix tomcat instance settings on RHEL 7

### DIFF
--- a/manifests/instance/config/systemd_env.pp
+++ b/manifests/instance/config/systemd_env.pp
@@ -1,0 +1,19 @@
+define tomcat::instance::config::systemd_env (
+  $instance,
+  $target,
+) {
+
+  $split_env = split($title, '=')
+  $env_name = $split_env[0]
+
+  $env_val = inline_template('<%= @split_env[1][0] == \'"\' and @split_env[1][-1] == \'"\' ? @split_env[1].slice(1..-2) : @split_env[1] %>')
+
+  shellvar {"${env_name}_${instance}":
+    ensure    => present,
+    target    => $target,
+    variable  => $env_name,
+    value     => $env_val,
+    uncomment => true,
+  }
+
+}

--- a/spec/defines/tomcat_instance_spec.rb
+++ b/spec/defines/tomcat_instance_spec.rb
@@ -261,26 +261,28 @@ describe 'tomcat::instance' do
         end
       end
 
-      describe "should create bin/setenv.sh" do
-        it {
-          should contain_concat("/srv/tomcat/fooBar/bin/setenv.sh").with({
-            'ensure'  => 'present',
-            'owner'   => 'root',
-            'group'   => 'adm',
-            'mode'    => '0754',
-          })
-        }
-      end
+      if facts[:osfamily] != 'RedHat' or facts[:operatingsystemmajrelease].to_i < 7
+        describe "should create bin/setenv.sh" do
+          it {
+            should contain_concat("/srv/tomcat/fooBar/bin/setenv.sh").with({
+              'ensure'  => 'present',
+              'owner'   => 'root',
+              'group'   => 'adm',
+              'mode'    => '0754',
+            })
+          }
+        end
 
-      describe "should create bin/setenv-local.sh" do
-        it {
-          should contain_file("/srv/tomcat/fooBar/bin/setenv-local.sh").with({
-            'ensure'  => 'present',
-            'owner'   => 'root',
-            'group'   => 'adm',
-            'mode'    => '0574',
-          })
-        }
+        describe "should create bin/setenv-local.sh" do
+          it {
+            should contain_file("/srv/tomcat/fooBar/bin/setenv-local.sh").with({
+              'ensure'  => 'present',
+              'owner'   => 'root',
+              'group'   => 'adm',
+              'mode'    => '0574',
+            })
+          }
+        end
       end
 
       describe "should have tomcat-fooBar server" do
@@ -338,14 +340,27 @@ describe 'tomcat::instance' do
           :setenv => ['JAVA_XMX="512m"', 'JAVA_XX_MAXPERMSIZE="512m"']
         }}
         it {
-          should contain_concat('/srv/tomcat/fooBar/bin/setenv.sh').with({
-            'ensure'  => 'present',
-            'owner'   => 'root',
-            'group'   => 'adm',
-            'mode'    => '0754',
-          })
-          should contain_concat__fragment('setenv.sh_fooBar+01_header').with_content(/JAVA_XMX=\"512m\"/)
-          should contain_concat__fragment('setenv.sh_fooBar+01_header').with_content(/JAVA_XX_MAXPERMSIZE=\"512m\"/)
+          if facts[:osfamily] != 'RedHat' or facts[:operatingsystemmajrelease].to_i < 7
+            should contain_concat('/srv/tomcat/fooBar/bin/setenv.sh').with({
+              'ensure'  => 'present',
+              'owner'   => 'root',
+              'group'   => 'adm',
+              'mode'    => '0754',
+            })
+            should contain_concat__fragment('setenv.sh_fooBar+01_header').with_content(/JAVA_XMX=\"512m\"/)
+            should contain_concat__fragment('setenv.sh_fooBar+01_header').with_content(/JAVA_XX_MAXPERMSIZE=\"512m\"/)
+          else
+            should contain_shellvar('JAVA_XMX_fooBar').with({
+              'target'   => '/etc/sysconfig/tomcat-fooBar',
+              'variable' => 'JAVA_XMX',
+              'value'    => '512m',
+            })
+            should contain_shellvar('JAVA_XX_MAXPERMSIZE_fooBar').with({
+              'target'   => '/etc/sysconfig/tomcat-fooBar',
+              'variable' => 'JAVA_XX_MAXPERMSIZE',
+              'value'    => '512m',
+            })
+          end
         }
       end
 


### PR DESCRIPTION
Problem: RHEL 7 uses systemd unit files to manage the service, which can only
be passed "Environment Files", which are not bash scripts but key=value files
which look like it. This means we cannot use the setenv.sh and setenv-local.sh
files to set env vars. Everything has to be set in the sysconfig/tomcat-xxx
file.