### PR TITLE
Add support for systemd limit per instance

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -65,6 +65,8 @@
 #   server.xml
 # - *catalina_logrotate*: install an UNMANAGED logrotate configuration file,
 #   to handle the catalina.out file of the instance. Default to true.
+# - *systemd_nofile*: number of open files limit configuration in systemd unit.
+#   This has no effect on systems where tomcat is not managed by systemd.
 #
 # Requires:
 # - one of the tomcat classes which installs tomcat binaries.
@@ -123,6 +125,7 @@ define tomcat::instance(
   $tomcat_version     = $tomcat::version,
   $catalina_logrotate = true,
   $java_opts          = undef,
+  $systemd_nofile     = '4096',
 ) {
 
   Class['tomcat::install'] -> Tomcat::Instance[$title]
@@ -184,6 +187,7 @@ define tomcat::instance(
     version            => $version,
     web_xml_file       => $web_xml_file,
     java_opts          => $java_opts,
+    systemd_nofile     => $systemd_nofile,
   }
 
   tomcat::instance::service { $title:

--- a/manifests/instance/config.pp
+++ b/manifests/instance/config.pp
@@ -25,6 +25,7 @@ define tomcat::instance::config(
   $server_xml_file = undef,
   $web_xml_file    = undef,
   $java_opts       = undef,
+  $systemd_nofile  = undef,
 ) {
   # lint:ignore:only_variable_string
   validate_re("${server_port}", '^[0-9]+$')
@@ -192,6 +193,7 @@ define tomcat::instance::config(
       content => ".include /usr/lib/systemd/system/tomcat.service
 [Service]
 UMask=${umask}
+LimitNOFILE=${systemd_nofile}
 Environment=\"SERVICE_NAME=tomcat-${name}\"
 EnvironmentFile=-/etc/sysconfig/tomcat-${name}
 ",

--- a/spec/defines/tomcat_instance_spec.rb
+++ b/spec/defines/tomcat_instance_spec.rb
@@ -328,7 +328,7 @@ describe 'tomcat::instance' do
                 'ensure' => 'file',
                 'owner'  => 'root',
                 'mode'   => '0644',
-                'content' => ".include /usr/lib/systemd/system/tomcat.service\n[Service]\nUMask=0002\nEnvironment=\"SERVICE_NAME=tomcat-fooBar\"\nEnvironmentFile=-/etc/sysconfig/tomcat-fooBar\n",
+                'content' => ".include /usr/lib/systemd/system/tomcat.service\n[Service]\nUMask=0002\nLimitNOFILE=4096\nEnvironment=\"SERVICE_NAME=tomcat-fooBar\"\nEnvironmentFile=-/etc/sysconfig/tomcat-fooBar\n",
               })
             end
           end


### PR DESCRIPTION
`tomcat::ulimit` which configures limits in `/etc/security/limits.conf` has no effect on systems where tomcat is managed by systemd.