### PR TITLE
Drop debian 7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,6 @@ matrix:
     sudo: required
     dist: trusty
     services: docker
-    env: BEAKER_set="debian-7"
-    bundler_args:
-    script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb
-  - rvm: default
-    sudo: required
-    dist: trusty
-    services: docker
     env: BEAKER_set="debian-8"
     bundler_args:
     script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb


### PR DESCRIPTION
# What does this PR does ? 
It drops debian 7 support. Debian 7 is now EOL. 

https://wiki.debian.org/LTS