### PR TITLE
Add tomcat 9 and allow to choose digest type

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@ class tomcat (
   $srcversion        = undef,
   $sources           = false,
   $sources_src       = $tomcat::params::sources_src,
+  $digest_type       = undef,
   $instance_basedir  = $tomcat::params::instance_basedir,
   $tomcat_uid        = undef,
   $tomcat_gid        = undef,
@@ -13,7 +14,7 @@ class tomcat (
   $system_conf_owner = 'root',
 ) inherits ::tomcat::params {
 
-  validate_re($version, '^[5-8]([\.0-9]+)?$')
+  validate_re($version, '^[5-9]([\.0-9]+)?$')
   validate_bool($sources)
   validate_absolute_path($instance_basedir)
   validate_hash($ulimits)
@@ -32,6 +33,7 @@ class tomcat (
       '6' => '6.0.26',
       '7' => '7.0.42',
       '8' => '8.0.15',
+      '9' => '9.0.6',
     }
   }
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -146,7 +146,7 @@ define tomcat::instance(
   validate_absolute_path($instance_basedir)
 
   $version = $tomcat_version
-  validate_re($version, '^[5-8]([\.0-9]+)?$')
+  validate_re($version, '^[5-9]([\.0-9]+)?$')
 
   $basedir = "${instance_basedir}/${name}"
 

--- a/manifests/instance/config.pp
+++ b/manifests/instance/config.pp
@@ -99,6 +99,7 @@ define tomcat::instance::config(
     '6' => 'server.xml.tomcat6.erb',
     '7' => 'server.xml.tomcat7.erb',
     '8' => 'server.xml.tomcat8.erb',
+    '9' => 'server.xml.tomcat9.erb',
   }
 
   case $ensure {

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -24,6 +24,13 @@ class tomcat::source {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
+  if $tomcat::digest_type != undef and $tomcat::digest_type != '' {
+    $tomcat_digest_type = $tomcat::digest_type
+  } else {
+    # Keep the retrocompatibility.
+    $tomcat_digest_type = 'md5'
+  }
+
   $version     = $tomcat::src_version
   $sources_src = $tomcat::sources_src
 
@@ -46,8 +53,8 @@ class tomcat::source {
     source       => $tomcaturl,
     extract      => true,
     path         => "/var/tmp/${tomcat_name}.tar.gz",
-    digest_url   => "${tomcaturl}.md5",
-    digest_type  => 'md5',
+    digest_url   => "${tomcaturl}.${tomcat_digest_type}",
+    digest_type  => $tomcat_digest_type,
     extract_path => '/opt',
     creates      => "/opt/${tomcat_name}/bin",
   }

--- a/templates/body1_server.xml.tomcat9.erb
+++ b/templates/body1_server.xml.tomcat9.erb
@@ -1,0 +1,59 @@
+]>
+<% if @manage -%>
+<!-- file managed by puppet -->
+<% else -%>
+<!-- file created (but not managed by puppet -->
+<% end -%>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="<%= @server_port %>" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <!--
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  -->
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+

--- a/templates/body2_server.xml.tomcat9.erb
+++ b/templates/body2_server.xml.tomcat9.erb
@@ -1,0 +1,50 @@
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>
+


### PR DESCRIPTION
### What does this pull request do ?

It adds tomcat version 9 compatibility.
Highly inspired from https://github.com/camptocamp/puppet-tomcat/pull/174

As tomcat do not provide md5sum files anymore, it will take digest_type md5 by default for retro-compatibility, but it will be possible to override this default.