### PR TITLE
fix: remove unnecessary and problematic init file

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -46,13 +46,6 @@ class tomcat::install {
       if $::osfamily == 'RedHat' {
         class {'::tomcat::install::redhat': }
       }
-
-      # Set the init script unexecutable
-      file {"/etc/init.d/tomcat${tomcat::version}":
-        ensure  => file,
-        mode    => '0644',
-        require => Service['tomcat'],
-      }
     }
 
   } else {


### PR DESCRIPTION
When trying to install tomcat from distribution (buster in my case) package:
```
Notice: /Stage[main]/Java/Package[java]/ensure: created (corrective)
Notice: /Stage[main]/Tomcat::Install/Package[tomcat]/ensure: created (corrective)
Error: Could not disable tomcat9: 
Error: /Stage[main]/Tomcat::Install/Service[tomcat]/enable: change from 'true' to 'false' failed: Could not disable tomcat9:  (corrective)
```
It is trying to disable a service via a non-executable file which is empty....
When not creating this file:
```
Notice: /Stage[main]/Java/Package[java]/ensure: created (corrective)
Notice: /Stage[main]/Tomcat::Install/Package[tomcat]/ensure: created (corrective)
Notice: /Stage[main]/Tomcat::Install/Service[tomcat]/ensure: ensure changed 'running' to 'stopped' (corrective)
```